### PR TITLE
work with promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,46 @@ For example, let's add another expectation for a different number, notice how je
       at waitUntil.catch (src/index.js:61:5)
 ```
 
+Since 0.6.0 we can now work with promises, for example, this is now possible:
+
+```javascript
+    test("rename todo by typing", async () => {
+      (..)
+      const todoToChange = getTodoByText("original todo");
+      todoToChange.value = "different text now";
+      Simulate.change(todoToChange);
+
+      await wait(() =>
+        expect(
+          todoItemsCollection.findOne({
+            text: "different text now"
+          })).resolves.not.toBeNull()
+      );
+    });
+```
+
+Async Await also works, as in this example - straight from our test case
+
+```javascript
+test("it works with promises", async () => {
+  let numberToChange = 10;
+  const randomTimeout = Math.floor(Math.random() * 300);
+
+  setTimeout(() => {
+    numberToChange = 100;
+  }, randomTimeout);
+
+  const sleep = (ms: number) =>
+    new Promise(resolve => setTimeout(() => resolve(), ms));
+
+  await waitForExpect(async () => {
+    await sleep(10);
+    expect(numberToChange).toEqual(100);
+  });
+});
+```
+
+(Note: Obviously, in this case it doesn't make sense to put the await sleep there, this is just for demonstration purpose)
 
 # API
 waitForExpect takes 3 arguments, 2 optional.
@@ -122,6 +162,9 @@ waitForExpect takes 3 arguments, 2 optional.
 ```
 
 ## Changelog
+0.6.0 - 3 May 2018
+Work with promises.
+
 0.5.0 - 10 April 2018
 Play nicely with jest fake timers (and also in any test tool that overwrites setTimeout) - thanks to @slightlytyler and @kentcoddods for helping to get this resolved.
 

--- a/README.md
+++ b/README.md
@@ -109,19 +109,19 @@ For example, let's add another expectation for a different number, notice how je
 Since 0.6.0 we can now work with promises, for example, this is now possible:
 
 ```javascript
-    test("rename todo by typing", async () => {
-      (..)
-      const todoToChange = getTodoByText("original todo");
-      todoToChange.value = "different text now";
-      Simulate.change(todoToChange);
+test("rename todo by typing", async () => {
+  // (..)
+  const todoToChange = getTodoByText("original todo");
+  todoToChange.value = "different text now";
+  Simulate.change(todoToChange);
 
-      await wait(() =>
-        expect(
-          todoItemsCollection.findOne({
-            text: "different text now"
-          })).resolves.not.toBeNull()
-      );
-    });
+  await waitForExpect(() =>
+    expect(
+      todoItemsCollection.findOne({
+        text: "different text now"
+      })).resolves.not.toBeNull()
+  );
+});
 ```
 
 Async Await also works, as in this example - straight from our test case
@@ -135,7 +135,7 @@ test("it works with promises", async () => {
     numberToChange = 100;
   }, randomTimeout);
 
-  const sleep = (ms: number) =>
+  const sleep = (ms) =>
     new Promise(resolve => setTimeout(() => resolve(), ms));
 
   await waitForExpect(async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wait-for-expect",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wait-for-expect",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Wait for expectation to be true, useful for integration and end to end testing",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,15 +17,20 @@ const waitForExpect = function waitForExpect(
 ) {
   const startTime = Date.now();
   return new Promise((resolve, reject) => {
+    const rejectOrRerun = (error: Error) => {
+      if (Date.now() - startTime >= timeout) {
+        reject(error);
+      }
+      // eslint-disable-next-line no-use-before-define
+      setTimeout(runExpectation, interval);
+    };
     function runExpectation() {
       try {
-        expectation();
-        resolve();
+        Promise.resolve(expectation())
+          .then(() => resolve())
+          .catch(rejectOrRerun);
       } catch (error) {
-        if (Date.now() - startTime >= timeout) {
-          reject(error);
-        }
-        setTimeout(runExpectation, interval);
+        rejectOrRerun(error);
       }
     }
     setTimeout(runExpectation, 0);

--- a/src/waitForExpect.spec.ts
+++ b/src/waitForExpect.spec.ts
@@ -80,3 +80,20 @@ test("it reruns the expectation every x ms, as provided with the second argument
     });
   }
 });
+
+test("it works with promises", async () => {
+  let numberToChange = 10;
+  const randomTimeout = Math.floor(Math.random() * 300);
+
+  setTimeout(() => {
+    numberToChange = 100;
+  }, randomTimeout);
+
+  const sleep = (ms: number) =>
+    new Promise(resolve => setTimeout(() => resolve(), ms));
+
+  await waitForExpect(async () => {
+    await sleep(10);
+    expect(numberToChange).toEqual(100);
+  });
+});


### PR DESCRIPTION
Hey @kentcdodds  👋 
Would you find some time to review this change? 

It helped me with integration tests in a rare case when I can't easily verify the result of a user action in the UI - text is saved on onChange with a throttle. I would have to move away from that page and come back to verify that the change is still there - but I think going to the db, in this case, is more readable and less brittle. 

Obviously, I can have a "saved" indicator in a situation like that - but it won't tell me whether my change was actually changed. 

I'm building a full-fledged apollo example with react-testing-library where I basically treat my server as an implementation detail, and test everything through the user actions, I looove it :) can't wait to make a blogpost about it. 