### PR TITLE
Added babel plugin which adds module exports when doing export default.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
   ],
   "plugins": [
     "@babel/proposal-class-properties",
-    "@babel/proposal-object-rest-spread"
+    "@babel/proposal-object-rest-spread",
+    "add-module-exports"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wait-for-expect",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1146,6 +1146,12 @@
       "requires": {
         "babel-runtime": "6.26.0"
       }
+    },
+    "babel-plugin-add-module-exports": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
+      "integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU=",
+      "dev": true
     },
     "babel-plugin-istanbul": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/typescript": "^2.0.0",
     "babel-core": "^7.0.0-0",
     "babel-jest": "^22.4.3",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",


### PR DESCRIPTION
From Babel@6 module.exports is not exported when doing export default. Added babel plugin which brings it back.
This PR solves #8.

Tested it by building the library locally and by importing & requiring waitForExpect in tests from built /lib folder. All of the tests are passing.