### PR TITLE
(#12) use real Date.now to avoid using potentially mocked one

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
+// Augment Window interface with the Date declaratoin,
+// because typescript does not expose it for now.
+// Check https://github.com/Microsoft/TypeScript/issues/19816 for more info
+declare global {
+  /* eslint-disable-next-line no-undef */
+  interface Window {
+    Date: typeof Date;
+  }
+}
 // Used to avoid using Jest's fake timers and Date.now mocks
 // See https://github.com/TheBrainFamily/wait-for-expect/issues/4 and
 // https://github.com/TheBrainFamily/wait-for-expect/issues/12 for more info

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
-// Used to avoid using Jest's fake timers.
-// See https://github.com/TheBrainFamily/wait-for-expect/issues/4 for more info
-const { setTimeout } = typeof window !== "undefined" ? window : global;
+// Used to avoid using Jest's fake timers and Date.now mocks
+// See https://github.com/TheBrainFamily/wait-for-expect/issues/4 and
+// https://github.com/TheBrainFamily/wait-for-expect/issues/12 for more info
+const { setTimeout, Date: { now } } =
+  typeof window !== "undefined" ? window : global;
 
 /**
  * Waits for the expectation to pass and returns a Promise
@@ -15,10 +17,10 @@ const waitForExpect = function waitForExpect(
   timeout = 4500,
   interval = 50
 ) {
-  const startTime = Date.now();
+  const startTime = now();
   return new Promise((resolve, reject) => {
     const rejectOrRerun = (error: Error) => {
-      if (Date.now() - startTime >= timeout) {
+      if (now() - startTime >= timeout) {
         reject(error);
         return;
       }

--- a/src/withFakeTimers.spec.ts
+++ b/src/withFakeTimers.spec.ts
@@ -32,12 +32,14 @@ test("it works even if the timers are overwritten by jest", async () => {
 // via mocking whole Date, or by mocking just Date.now
 // hence two test cases covered both ways
 test("it works even if the Date was mocked", async () => {
-  /* eslint-disable-next-line no-global-assign */
+  /* eslint-disable no-global-assign */
+  // @ts-ignore: Cannot reassign to const Date
   Date = jest.fn(() => ({
     now() {
       return 1482363367071;
     }
   }));
+  /* eslint-enable */
   let numberToChange = 10;
 
   setTimeout(() => {

--- a/src/withFakeTimers.spec.ts
+++ b/src/withFakeTimers.spec.ts
@@ -2,9 +2,14 @@
 import "./toBeInRangeMatcher";
 import waitForExpect from "./index";
 
-// this is a copy of "it waits for expectation to pass" modified to use jestFakeTimers
-// This breakes when we remove the const { setTimeout } = typeof window !== "undefined" ? window : global;
+// this is a copy of "it waits for expectation to pass" modified to use jestFakeTimers and two ways of Date.now mocking
+// This breakes when we remove the const { setTimeout, Date: { now } } = typeof window !== "undefined" ? window : global;
 // line from the index.ts
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.useRealTimers();
+});
 
 test("it works even if the timers are overwritten by jest", async () => {
   jest.useFakeTimers();
@@ -21,4 +26,54 @@ test("it works even if the timers are overwritten by jest", async () => {
   await waitForExpect(() => {
     expect(numberToChange).toEqual(100);
   });
+});
+
+// Date.now might be mocked with two main ways:
+// via mocking whole Date, or by mocking just Date.now
+// hence two test cases covered both ways
+test("it works even if the Date was mocked", async () => {
+  /* eslint-disable-next-line no-global-assign */
+  Date = jest.fn(() => ({
+    now() {
+      return 1482363367071;
+    }
+  }));
+  let numberToChange = 10;
+
+  setTimeout(() => {
+    numberToChange = 100;
+  }, 100);
+  let expectFailingMessage;
+  try {
+    await waitForExpect(() => {
+      expect(numberToChange).toEqual(101);
+    }, 1000);
+  } catch (e) {
+    expectFailingMessage = e.message;
+  }
+  expect(expectFailingMessage).toMatch("Expected value to equal:");
+  expect(expectFailingMessage).toMatch("101");
+  expect(expectFailingMessage).toMatch("Received:");
+  expect(expectFailingMessage).toMatch("100");
+});
+
+test("it works even if the Date.now was mocked", async () => {
+  Date.now = jest.fn(() => 1482363367071);
+  let numberToChange = 10;
+
+  setTimeout(() => {
+    numberToChange = 100;
+  }, 100);
+  let expectFailingMessage;
+  try {
+    await waitForExpect(() => {
+      expect(numberToChange).toEqual(101);
+    }, 1000);
+  } catch (e) {
+    expectFailingMessage = e.message;
+  }
+  expect(expectFailingMessage).toMatch("Expected value to equal:");
+  expect(expectFailingMessage).toMatch("101");
+  expect(expectFailingMessage).toMatch("Received:");
+  expect(expectFailingMessage).toMatch("100");
 });


### PR DESCRIPTION
This is the PR for #12 

I decided to go with mostly copy-pasting test cases for being more explicit with them. Their async matter already hard enough to understand even without extracting common parts, but if you insist, I'll do this :)

What do you think?