### PR TITLE
feat: configurable default timeout and interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ waitForExpect takes 3 arguments, 2 optional.
  */
 ```
 
+The defaults for `timeout` and `interval` can also be edited globally, e.g. in a jest setup file:
+```javascript
+import waitForExpect from 'wait-for-expect';
+
+waitForExpect.defaults.timeout = 2000;
+waitForExpect.defaults.interval = 10;
+```
+
 ## Changelog
 1.0.0 - 15 June 2018
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ declare global {
 const { setTimeout, Date: { now } } =
   typeof window !== "undefined" ? window : global;
 
+const defaults = {
+  timeout: 4500,
+  interval: 50,
+}
+
 /**
  * Waits for the expectation to pass and returns a Promise
  *
@@ -23,8 +28,8 @@ const { setTimeout, Date: { now } } =
  */
 const waitForExpect = function waitForExpect(
   expectation: () => void,
-  timeout = 4500,
-  interval = 50
+  timeout = defaults.timeout,
+  interval = defaults.interval
 ) {
   const startTime = now();
   return new Promise((resolve, reject) => {
@@ -49,4 +54,4 @@ const waitForExpect = function waitForExpect(
   });
 };
 
-export default waitForExpect;
+export default Object.assign(waitForExpect, { defaults });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ const { setTimeout, Date: { now } } =
 
 const defaults = {
   timeout: 4500,
-  interval: 50,
-}
+  interval: 50
+};
 
 /**
  * Waits for the expectation to pass and returns a Promise

--- a/src/waitForExpect.spec.ts
+++ b/src/waitForExpect.spec.ts
@@ -2,6 +2,11 @@
 import "./toBeInRangeMatcher";
 import waitForExpect from "./index";
 
+const originalDefaults = { ...waitForExpect.defaults }
+beforeEach(() => {
+  Object.assign(waitForExpect.defaults, originalDefaults)
+})
+
 test("it waits for expectation to pass", async () => {
   let numberToChange = 10;
   // we are using random timeout here to simulate a real-time example
@@ -78,6 +83,24 @@ test("it reruns the expectation every x ms, as provided with the second argument
       min: expectedTimesToRun - 1,
       max: expectedTimesToRun + 1
     });
+  }
+});
+
+test("it reruns the expectation every x ms, as provided by the default timeout and interval", async () => {
+  const timeout = 600;
+  const interval = 150;
+  waitForExpect.defaults.timeout = timeout;
+  waitForExpect.defaults.interval = interval;
+  const mockExpectation = jest.fn().mockImplementation(
+    () => expect(true).toEqual(false)
+  )
+  try {
+    await waitForExpect(mockExpectation);
+    throw Error('waitForExpect should have thrown')
+  } catch (e) {
+    // initial run + reruns
+    const expectedTimesToRun = 1 + Math.floor(timeout / interval);
+    expect(mockExpectation).toHaveBeenCalledTimes(expectedTimesToRun);
   }
 });
 

--- a/src/waitForExpect.spec.ts
+++ b/src/waitForExpect.spec.ts
@@ -2,10 +2,10 @@
 import "./toBeInRangeMatcher";
 import waitForExpect from "./index";
 
-const originalDefaults = { ...waitForExpect.defaults }
+const originalDefaults = { ...waitForExpect.defaults };
 beforeEach(() => {
-  Object.assign(waitForExpect.defaults, originalDefaults)
-})
+  Object.assign(waitForExpect.defaults, originalDefaults);
+});
 
 test("it waits for expectation to pass", async () => {
   let numberToChange = 10;
@@ -91,12 +91,11 @@ test("it reruns the expectation every x ms, as provided by the default timeout a
   const interval = 150;
   waitForExpect.defaults.timeout = timeout;
   waitForExpect.defaults.interval = interval;
-  const mockExpectation = jest.fn().mockImplementation(
-    () => expect(true).toEqual(false)
-  )
+  const mockExpectation = jest.fn();
+  mockExpectation.mockImplementation(() => expect(true).toEqual(false));
   try {
     await waitForExpect(mockExpectation);
-    throw Error('waitForExpect should have thrown')
+    throw Error("waitForExpect should have thrown");
   } catch (e) {
     // initial run + reruns
     const expectedTimesToRun = 1 + Math.floor(timeout / interval);


### PR DESCRIPTION
Hey - love the library! This is a very small PR to allow setting the default timeout and interval globally.

Was going to make an issue but I thought this was simple enough that a PR would be about as easy. Obviously up to you if you want this to go in - it's possible to workaround by wrapping this library's export, but I found myself doing that in a lot of projects, so I wondered if you'd be open to supporting it out-of-the box.

Side note - I noticed there's a file `src/index.d.ts`, but I'm not sure what this does, since the declaration files are generated by `npm run build` (which outputs `lib/index.d.ts`, matching what's in `package.json`). I left it, but it could probably be safely deleted, along with the other `*.d.ts` files under `src`.