### PR TITLE
Get setTimeout lazily

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,6 @@ declare global {
     Date: typeof Date;
   }
 }
-// Used to avoid using Jest's fake timers and Date.now mocks
-// See https://github.com/TheBrainFamily/wait-for-expect/issues/4 and
-// https://github.com/TheBrainFamily/wait-for-expect/issues/12 for more info
-const { setTimeout, Date: { now } } =
-  typeof window !== "undefined" ? window : global;
 
 const defaults = {
   timeout: 4500,
@@ -31,6 +26,12 @@ const waitForExpect = function waitForExpect(
   timeout = defaults.timeout,
   interval = defaults.interval
 ) {
+  // Used to avoid using Jest's fake timers and Date.now mocks
+  // See https://github.com/TheBrainFamily/wait-for-expect/issues/4 and
+  // https://github.com/TheBrainFamily/wait-for-expect/issues/12 for more info
+  const { setTimeout, Date: { now } } =
+    typeof window !== "undefined" ? window : global;
+
   const startTime = now();
   return new Promise((resolve, reject) => {
     const rejectOrRerun = (error: Error) => {

--- a/src/withFakeTimers.spec.ts
+++ b/src/withFakeTimers.spec.ts
@@ -7,12 +7,16 @@ import waitForExpect from "./index";
 // line from the index.ts
 
 beforeEach(() => {
+  jest.resetModules();
   jest.restoreAllMocks();
   jest.useRealTimers();
 });
 
-test("it works even if the timers are overwritten by jest", async () => {
+test("it works with real timers even if they were set to fake before importing the module", async () => {
   jest.useFakeTimers();
+  const importedWaitForExpect = require('./index');
+  jest.useRealTimers();
+
   let numberToChange = 10;
   // we are using random timeout here to simulate a real-time example
   // of an async operation calling a callback at a non-deterministic time
@@ -22,8 +26,7 @@ test("it works even if the timers are overwritten by jest", async () => {
     numberToChange = 100;
   }, randomTimeout);
 
-  jest.runAllTimers();
-  await waitForExpect(() => {
+  await importedWaitForExpect(() => {
     expect(numberToChange).toEqual(100);
   });
 });

--- a/src/withFakeTimers.spec.ts
+++ b/src/withFakeTimers.spec.ts
@@ -14,7 +14,8 @@ beforeEach(() => {
 
 test("it works with real timers even if they were set to fake before importing the module", async () => {
   jest.useFakeTimers();
-  const importedWaitForExpect = require('./index');
+  /* eslint-disable global-require */
+  const importedWaitForExpect = require("./index");
   jest.useRealTimers();
 
   let numberToChange = 10;


### PR DESCRIPTION
This prevents from using old versions of setTimeout/Date.now.

Previously, if jest's timers were set as `fake` by default and then you wanted to use real timers in a test suite with `jest.useRealTimers()`, the `waitForExpect` function would still use the default functions.

**Solution**: The functions just need to be gotten every time the function is called.