### PR TITLE
Avoid relying on Date.now

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,7 @@
-// Augment Window interface with the Date declaratoin,
-// because typescript does not expose it for now.
-// Check https://github.com/Microsoft/TypeScript/issues/19816 for more info
-declare global {
-  /* eslint-disable-next-line no-undef */
-  interface Window {
-    Date: typeof Date;
-  }
-}
 // Used to avoid using Jest's fake timers and Date.now mocks
 // See https://github.com/TheBrainFamily/wait-for-expect/issues/4 and
 // https://github.com/TheBrainFamily/wait-for-expect/issues/12 for more info
-const { setTimeout, Date: { now } } =
-  typeof window !== "undefined" ? window : global;
+const { setTimeout } = typeof window !== "undefined" ? window : global;
 
 const defaults = {
   timeout: 4500,
@@ -31,10 +21,11 @@ const waitForExpect = function waitForExpect(
   timeout = defaults.timeout,
   interval = defaults.interval
 ) {
-  const startTime = now();
+  const maxTries = Math.ceil(timeout / interval);
+  let tries = 0;
   return new Promise((resolve, reject) => {
     const rejectOrRerun = (error: Error) => {
-      if (now() - startTime >= timeout) {
+      if (tries > maxTries) {
         reject(error);
         return;
       }
@@ -42,6 +33,7 @@ const waitForExpect = function waitForExpect(
       setTimeout(runExpectation, interval);
     };
     function runExpectation() {
+      tries += 1;
       try {
         Promise.resolve(expectation())
           .then(() => resolve())

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ const waitForExpect = function waitForExpect(
   timeout = defaults.timeout,
   interval = defaults.interval
 ) {
+  if (interval < 1) throw new Error("waitForExpect: interval must be >= 1ms");
   const maxTries = Math.ceil(timeout / interval);
   let tries = 0;
   return new Promise((resolve, reject) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ const waitForExpect = function waitForExpect(
   timeout = defaults.timeout,
   interval = defaults.interval
 ) {
-  if (interval < 1) throw new Error("waitForExpect: interval must be >= 1ms");
+  // eslint-disable-next-line no-param-reassign
+  if (interval < 1) interval = 1;
   const maxTries = Math.ceil(timeout / interval);
   let tries = 0;
   return new Promise((resolve, reject) => {

--- a/src/waitForExpect.spec.ts
+++ b/src/waitForExpect.spec.ts
@@ -120,10 +120,17 @@ test("it works with promises", async () => {
   });
 });
 
-test("it rejects a zero interval", async () => {
-  try {
-    await waitForExpect(() => expect(true).toEqual(false), 1, 0);
-  } catch (error) {
-    expect(error.message).toMatch(/interval must be >= 1ms/);
-  }
+test("it works with a zero interval", async () => {
+  let numberToChange = 1;
+  setTimeout(() => {
+    numberToChange = 2;
+  }, 10);
+
+  await waitForExpect(
+    () => {
+      expect(numberToChange).toEqual(2);
+    },
+    100,
+    0
+  );
 });

--- a/src/waitForExpect.spec.ts
+++ b/src/waitForExpect.spec.ts
@@ -119,3 +119,11 @@ test("it works with promises", async () => {
     expect(numberToChange).toEqual(100);
   });
 });
+
+test("it rejects a zero interval", async () => {
+  try {
+    await waitForExpect(() => expect(true).toEqual(false), 1, 0);
+  } catch (error) {
+    expect(error.message).toMatch(/interval must be >= 1ms/);
+  }
+});


### PR DESCRIPTION
### Background

Several issues have been opened about problems with `Date` not existing on `window`/`global`:
- #15 
- #17 
- https://github.com/testing-library/dom-testing-library/issues/194

This is in particular a problem for users of `jsdom` when using dom-testing-library in its [recommended configuration without Jest](https://testing-library.com/docs/dom-testing-library/setup#using-without-jest).

This is because, in its default configuration, `jsdom` [does not expose globals](https://github.com/jsdom/jsdom/tree/699ed6b7bea3354bf7cd7c8f174193238999cda8#executing-scripts) such as [`window.Date`](https://github.com/jsdom/jsdom/tree/699ed6b7bea3354bf7cd7c8f174193238999cda8#basic-usage)

> Important note: in the default configuration, JavaScript globals like window.Date or window.Map will not exist.

There is a workaround (https://github.com/testing-library/dom-testing-library/issues/194#issuecomment-518041038 and https://github.com/TheBrainFamily/wait-for-expect/issues/17#issuecomment-493107110), which is to change how jsdom is loaded.

There is also a PR https://github.com/TheBrainFamily/wait-for-expect/pull/20 with another attempt to solve this, but the tests are not currently passing on that branch.

See also https://github.com/testing-library/dom-testing-library/issues/194#issuecomment-467234974 from @kentcdodds .

### Proposed Solution

Rather than relying on `Date.now`, use `setTimeout` and a number of tries computed based on the timeout and interval. For example, if you want to wait 4500ms and retry every 50ms, that's (roughly) the same as saying "try 90 (=4500/50) times, once every 50ms". 

It's probably a bit less accurate, because `setTimeout` isn't exact, and the errors may accumulate, but it is probably good enough, and it avoids relying on `Date`, which might not be there in `jsdom`. And it's maybe marginally more efficient, because it doesn't have to keep checking the system clock.