### PR TITLE
Add runWithRealTimers & getSetTimeoutFn functions

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,27 @@
+// Used to avoid using Jest's fake timers and Date.now mocks
+// See https://github.com/TheBrainFamily/wait-for-expect/issues/4 and
+// https://github.com/TheBrainFamily/wait-for-expect/issues/12 for more info
+const globalObj = typeof window === "undefined" ? global : window;
+
+// Currently this fn only supports jest timers, but it could support other test runners in the future.
+function runWithRealTimers(callback: () => any) {
+  const usingJestFakeTimers =
+    (globalObj.setTimeout as any)._isMockFunction &&
+    typeof jest !== "undefined";
+
+  if (usingJestFakeTimers) {
+    jest.useRealTimers();
+  }
+
+  const callbackReturnValue = callback();
+
+  if (usingJestFakeTimers) {
+    jest.useFakeTimers();
+  }
+
+  return callbackReturnValue;
+}
+
+export function getSetTimeoutFn() {
+  return runWithRealTimers(() => globalObj.setTimeout);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { getSetTimeoutFn } from "./helpers";
+
 const defaults = {
   timeout: 4500,
   interval: 50
@@ -16,10 +18,7 @@ const waitForExpect = function waitForExpect(
   timeout = defaults.timeout,
   interval = defaults.interval
 ) {
-  // Used to avoid using Jest's fake timers and Date.now mocks
-  // See https://github.com/TheBrainFamily/wait-for-expect/issues/4 and
-  // https://github.com/TheBrainFamily/wait-for-expect/issues/12 for more info
-  const { setTimeout } = typeof window !== "undefined" ? window : global;
+  const setTimeout = getSetTimeoutFn();
 
   // eslint-disable-next-line no-param-reassign
   if (interval < 1) interval = 1;

--- a/src/withFakeTimers.spec.ts
+++ b/src/withFakeTimers.spec.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
   jest.useRealTimers();
 });
 
-test("it works with real timers even if they were set to fake before importing the module", async () => {
+test("it always uses with real timers even if they were set to fake before importing the module", async () => {
   jest.useFakeTimers();
   /* eslint-disable global-require */
   const importedWaitForExpect = require("./index");
@@ -26,6 +26,8 @@ test("it works with real timers even if they were set to fake before importing t
   setTimeout(() => {
     numberToChange = 100;
   }, randomTimeout);
+
+  jest.useFakeTimers();
 
   await importedWaitForExpect(() => {
     expect(numberToChange).toEqual(100);

--- a/src/withFakeTimers.spec.ts
+++ b/src/withFakeTimers.spec.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
   jest.useRealTimers();
 });
 
-test("it always uses with real timers even if they were set to fake before importing the module", async () => {
+test("it always uses real timers even if they were set to fake before importing the module", async () => {
   jest.useFakeTimers();
   /* eslint-disable global-require */
   const importedWaitForExpect = require("./index");


### PR DESCRIPTION
After a long discussion in https://github.com/testing-library/dom-testing-library/pull/342, we ended up getting to the conclusion that it's better to have a util `runWithRealTimers` function that ensures that the passed callback is always run with real timers.
This function can also be extended to support other test runners as I mention in the comment that I left in the code.

**TL;DR** With this addition, developers won't have to worry about using real or fake timers because `wait-for-expect` will always use the real ones :smiley:  