### PR TITLE
 fix: Transpile Object.assign which is not available in IE 11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,7 @@
       {
         "addDefaultProperty": true
       }
-    ]
+    ],
+    "@babel/plugin-transform-object-assign"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -552,6 +552,23 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.42"
       }
     },
+    "@babel/plugin-transform-object-assign": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.2.0.tgz",
+      "integrity": "sha512-nmE55cZBPFgUktbF2OuoZgPRadfxosLOpSgzEPYotKSls9J4pEPcembi8r78RU37Rph6UApCpNmsQA4QMWK9Ng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+          "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-object-super": {
       "version": "7.0.0-beta.42",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.42.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/core": "^7.0.0-beta.42",
     "@babel/plugin-proposal-class-properties": "^7.0.0-beta.42",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.42",
+    "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/preset-env": "^7.0.0-beta.42",
     "@babel/preset-typescript": "^7.0.0-beta.42",
     "@types/eslint": "^4.16.0",


### PR DESCRIPTION
We're using `@testing-library/dom` which uses this package and like to run tests in IE11. Unfortunately Object.assign is not available in that environment.

Fortunately we can transpile it to be compatible with IE 11.

In later TypeScript versions (^3.1) `waitForExpect.defaults = defaults` would be accepted though I assumed this would be a more controversial change (bumping the TS version). See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#properties-declarations-on-functions. I'd be happy to work on bumping TS to 3.1 if you'd prefer that.