### PR TITLE
Add Promise<void> return type for expectation

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "transform": {
       "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
     },
-    "testRegex": "/src/.*\\.spec\\.(js|ts|tsx)$"
+    "testRegex": "/src/.*\\.spec\\.(js|ts|tsx)$",
+    "testURL": "http://localhost/"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,4 +6,4 @@
  * @param  interval  Number  Wait-between-retries interval, 50ms by default
  * @return  Promise  Promise to return a callback result
  */
-export default function waitForExpect(expectation: () => void, timeout?: number, interval?: number): any;
+export default function waitForExpect(expectation: () => void | Promise<void>, timeout?: number, interval?: number): any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const defaults = {
  * @return  Promise  Promise to return a callback result
  */
 const waitForExpect = function waitForExpect(
-  expectation: () => void,
+  expectation: () => void | Promise<void>,
   timeout = defaults.timeout,
   interval = defaults.interval
 ) {

--- a/src/waitForExpect.spec.ts
+++ b/src/waitForExpect.spec.ts
@@ -22,43 +22,35 @@ test("it waits for expectation to pass", async () => {
   });
 });
 
-test(
-  "it fails properly with jest error message when it times out without expectation passing",
-  async done => {
-    const numberNotToChange = 200;
-    try {
-      await waitForExpect(() => {
-        expect(numberNotToChange).toEqual(2000);
-      }, 300);
-    } catch (e) {
-      expect(e.message).toMatchSnapshot();
-      done();
-    }
-  },
-  1000
-);
+test("it fails properly with jest error message when it times out without expectation passing", async done => {
+  const numberNotToChange = 200;
+  try {
+    await waitForExpect(() => {
+      expect(numberNotToChange).toEqual(2000);
+    }, 300);
+  } catch (e) {
+    expect(e.message).toMatchSnapshot();
+    done();
+  }
+}, 1000);
 
-test(
-  "it fails when the change didn't happen fast enough, based on the waitForExpect timeout",
-  async done => {
-    let numberToChangeTooLate = 300;
-    const timeToPassForTheChangeToHappen = 1000;
+test("it fails when the change didn't happen fast enough, based on the waitForExpect timeout", async done => {
+  let numberToChangeTooLate = 300;
+  const timeToPassForTheChangeToHappen = 1000;
 
-    setTimeout(() => {
-      numberToChangeTooLate = 3000;
-    }, timeToPassForTheChangeToHappen);
+  setTimeout(() => {
+    numberToChangeTooLate = 3000;
+  }, timeToPassForTheChangeToHappen);
 
-    try {
-      await waitForExpect(() => {
-        expect(numberToChangeTooLate).toEqual(3000);
-      }, timeToPassForTheChangeToHappen - 200);
-    } catch (e) {
-      expect(e.message).toMatchSnapshot();
-      done();
-    }
-  },
-  1500
-);
+  try {
+    await waitForExpect(() => {
+      expect(numberToChangeTooLate).toEqual(3000);
+    }, timeToPassForTheChangeToHappen - 200);
+  } catch (e) {
+    expect(e.message).toMatchSnapshot();
+    done();
+  }
+}, 1500);
 
 test("it reruns the expectation every x ms, as provided with the second argument", async () => {
   // using this would be preferable but somehow jest shares the expect.assertions between tests!

--- a/src/waitForExpect.spec.ts
+++ b/src/waitForExpect.spec.ts
@@ -22,35 +22,43 @@ test("it waits for expectation to pass", async () => {
   });
 });
 
-test("it fails properly with jest error message when it times out without expectation passing", async done => {
-  const numberNotToChange = 200;
-  try {
-    await waitForExpect(() => {
-      expect(numberNotToChange).toEqual(2000);
-    }, 300);
-  } catch (e) {
-    expect(e.message).toMatchSnapshot();
-    done();
-  }
-}, 1000);
+test(
+  "it fails properly with jest error message when it times out without expectation passing",
+  async done => {
+    const numberNotToChange = 200;
+    try {
+      await waitForExpect(() => {
+        expect(numberNotToChange).toEqual(2000);
+      }, 300);
+    } catch (e) {
+      expect(e.message).toMatchSnapshot();
+      done();
+    }
+  },
+  1000
+);
 
-test("it fails when the change didn't happen fast enough, based on the waitForExpect timeout", async done => {
-  let numberToChangeTooLate = 300;
-  const timeToPassForTheChangeToHappen = 1000;
+test(
+  "it fails when the change didn't happen fast enough, based on the waitForExpect timeout",
+  async done => {
+    let numberToChangeTooLate = 300;
+    const timeToPassForTheChangeToHappen = 1000;
 
-  setTimeout(() => {
-    numberToChangeTooLate = 3000;
-  }, timeToPassForTheChangeToHappen);
+    setTimeout(() => {
+      numberToChangeTooLate = 3000;
+    }, timeToPassForTheChangeToHappen);
 
-  try {
-    await waitForExpect(() => {
-      expect(numberToChangeTooLate).toEqual(3000);
-    }, timeToPassForTheChangeToHappen - 200);
-  } catch (e) {
-    expect(e.message).toMatchSnapshot();
-    done();
-  }
-}, 1500);
+    try {
+      await waitForExpect(() => {
+        expect(numberToChangeTooLate).toEqual(3000);
+      }, timeToPassForTheChangeToHappen - 200);
+    } catch (e) {
+      expect(e.message).toMatchSnapshot();
+      done();
+    }
+  },
+  1500
+);
 
 test("it reruns the expectation every x ms, as provided with the second argument", async () => {
   // using this would be preferable but somehow jest shares the expect.assertions between tests!


### PR DESCRIPTION
Since 0.6.0 promises and async/await are supported and tested, but the return type of the expectation function did not yet reflect this change.