### PR TITLE
support for min consecutive passes

### DIFF
--- a/src/waitForExpect.spec.ts
+++ b/src/waitForExpect.spec.ts
@@ -134,3 +134,22 @@ test("it works with a zero interval", async () => {
     0
   );
 });
+
+test("it does not pass flaky tests", async () => {
+  waitForExpect.defaults.minConsecutivePasses = 3;
+  try {
+    let counter = 0;
+    await waitForExpect(() => {
+      // a flaky test that passes if retried enough times
+      counter += 1;
+      if (counter % 10 === 0) {
+        expect(true).toEqual(true);
+      } else {
+        expect(true).toEqual(false);
+      }
+    });
+    throw Error("waitForExpect should have thrown");
+  } catch ({ message }) {
+    expect(message).not.toEqual("waitForExpect should have thrown");
+  }
+});


### PR DESCRIPTION
Hello guys! here is a PR for you to consider.

I was inspired by an issue I encountered at work while using this library. It has been really useful to me otherwise, but I found in our large codebase some tests that were non-deterministic and flaky. waitForExpect would give us false positives in those cases because it will retry them until they pass. To solve this, I added an opt-in constrain (defaults to current behaviour for backwards compatibility). The idea is that a test will have to pass a number of consecutive times before it actually passes.

I added a simple test to account for this scenario I am describing.