### PR TITLE
Return the result of the callback in the promise

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,4 +6,4 @@
  * @param  interval  Number  Wait-between-retries interval, 50ms by default
  * @return  Promise  Promise to return a callback result
  */
-export default function waitForExpect(expectation: () => void | Promise<void>, timeout?: number, interval?: number): any;
+export default function waitForExpect<T>(expectation: () => T | Promise<T>, timeout?: number, interval?: number): Promise<T>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ const defaults = {
  * @param  interval  Number  Wait-between-retries interval, 50ms by default
  * @return  Promise  Promise to return a callback result
  */
-const waitForExpect = function waitForExpect(
-  expectation: () => void | Promise<void>,
+const waitForExpect = function waitForExpect<T>(
+  expectation: () => T | Promise<T>,
   timeout = defaults.timeout,
   interval = defaults.interval
 ) {
@@ -37,7 +37,7 @@ const waitForExpect = function waitForExpect(
       tries += 1;
       try {
         Promise.resolve(expectation())
-          .then(() => resolve())
+          .then(result => resolve(result))
           .catch(rejectOrRerun);
       } catch (error) {
         rejectOrRerun(error);


### PR DESCRIPTION
This makes the promise returned by wait-for-expect resolve to the same value returned by the supplied callback

This would allow you to do something like this without having to repeat the call to `getNumber`:

```javascript
const value = await waitForExpect(async() => {
    const val = await getNumber() // returns some number that might/should be greater than 50
    expect(val).toBeGreaterThan(50)
    return val
})
console.log(value > 50) // true
// Do something with value
```

My motivation for this is for use in the [pptr-testing-library](https://github.com/testing-library/pptr-testing-library) where it's wait function is (more or less) an alias for waitForExpect. In short I often want to wait for an element to exist on the page and then do something with the element. ie what I would like to do is this

```javascript
const $button = await wait(() => $document.getByRole("button"))
// Do something with $button ...
```