### PR TITLE
Fix handle jest v27 fake timers (issue #30)

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,9 +7,12 @@ const globalObj = typeof window === "undefined" ? global : window;
 
 // Currently this fn only supports jest timers, but it could support other test runners in the future.
 function runWithRealTimers(callback: () => any) {
+  // legacy jest timers mutate `global.setTimeout` differently to
+  // jest v27 fake timers; this checks hanldes both
   const usingJestFakeTimers =
     // eslint-disable-next-line no-underscore-dangle
-    (globalObj.setTimeout as any)._isMockFunction &&
+    ((globalObj.setTimeout as any)._isMockFunction ||
+      (globalObj.setTimeout as any).clock) &&
     typeof jest !== "undefined";
 
   if (usingJestFakeTimers) {


### PR DESCRIPTION
The existing check for jest fake timers no longer works as jest v27 mutates the `setTimeout` global differently. This patch checks for both the old and new formats.
